### PR TITLE
Minor style suggestions

### DIFF
--- a/topic-api-rest-create.md
+++ b/topic-api-rest-create.md
@@ -77,7 +77,7 @@ The [Robustness Principle](https://tools.ietf.org/html/rfc1122#page-12){: new_wi
 #### Producing APIs
 {: #robust-producer}
 
-When providing an API to external clients there are two things you must do when accepting requests and returning responses. 
+When providing an API to external clients there are two things you must do when accepting requests and returning responses: 
 
 * Accept unknown attributes as part of the request.
     > If a service calls your API with unnecessary attributes, just throw those values away. Returning an error in this scenario can cause unnecessary failures, negatively impacting the end user.
@@ -87,10 +87,11 @@ When providing an API to external clients there are two things you must do when 
 #### Consuming APIs
 {: #robust-consumer}
 
-Only validate the request against the variables or attributes that you need.
-    > Do not validate against variables just because they are provided. If you are not using them as part of your request, do not rely on them being there.
+When consuming APIs:
 
-Accept unknown attributes as part of the response.
+* Only validate the request against the variables or attributes that you need.
+    > Do not validate against variables just because they are provided. If you are not using them as part of your request, do not rely on them being there.
+* Accept unknown attributes as part of the response.
     > Do not issue an exception if you receive an unexpected variable. As long as the response contains the information you need, it does not matter what else comes along for the ride.
 
 These guidelines are especially relevant for strongly-typed languages like Java, where JSON serialization and deserialization often occurs indirectly, for example, by way of the Jackson libraries, or JSON-P/JSON-B. Look for language mechanisms that allow you to specify more generous behavior like ignoring unknown attributes, or to define or filter which attributes should be serialized.
@@ -146,7 +147,7 @@ In either case, working with an OpenAPI definition can help identify areas where
 
 You can author your OpenAPI YAML file in whatever tool you choose. Using a plain text editor, however, can be error prone. Some editors have basic support for YAML, and some might have additional extensions to support OpenAPI definitions. For example, you can use Visual Studio Code extensions like [Swagger Viewer](https://marketplace.visualstudio.com/items?itemName=Arjun.swagger-viewer){: new_window} ![External link icon](../icons/launch-glyph.svg "External link icon") or [OpenAPI Preview](https://marketplace.visualstudio.com/items?itemName=zoellner.openapi-preview){: new_window} ![External link icon](../icons/launch-glyph.svg "External link icon") to validate your OpenAPI definition against a specified spec version and render a web view in the preview pane:
 
-![OpenAPI Preview](images/create-api-image1.png "OpenAPI Preview") Figure 1. OpenAPI Preview 
+![OpenAPI Preview](images/create-api-image1.png "OpenAPI Preview")
 
 There are also a variety of browser-based, live-parsing editors that you can use either online or locally. Some examples include:
 
@@ -157,7 +158,7 @@ There are also a variety of browser-based, live-parsing editors that you can use
 ### Generating the API implementation
 {: #code-first}
 
-You can use the open-source [OpenAPI generator](https://github.com/OpenAPITools/openapi-generator){: new_window} ![External link icon](../icons/launch-glyph.svg "External link icon") to create a skeleton project for your service implementation from an OpenAPI definition. You can specify the language or framework for the skeleton from the command line. For example, to create a Java project for the sample PetStore API that uses generic JAX-RS method annotations, you specify the following:
+You can use the open-source [OpenAPI generator](https://github.com/OpenAPITools/openapi-generator){: new_window} ![External link icon](../icons/launch-glyph.svg "External link icon") to create a skeleton project for your service implementation from an OpenAPI definition. You can specify the language or framework for the skeleton from the command line. For example, to create a Java project for the sample PetStore API that uses generic JAX-RS method annotations, you specify the following command:
 
 ```bash
 openapi-generator generate -g jaxrs-cxf-cdi -i ./petstore.yaml -o petstore --api-package=com.ibm.petstore


### PR DESCRIPTION
Made 'consuming APIs' more similar format to the previous section. The indented bits were weirdly rendered in terminal-style lines with internal scrollbars which made them difficult to read. I think the intention may have been to follow the approach in the previous paragraph with indented paragraphs under list items.

Suggest removing captions from images as they're not necessary in online docs. The lead-in sentence makes clear what the image is about and the caption just adds clutter.