### PR TITLE
Minor style changes

### DIFF
--- a/topic-healthcheck.md
+++ b/topic-healthcheck.md
@@ -44,7 +44,7 @@ Configuring a readiness check very aggressively, such as with a low initial dela
 ## Best practices for configuring probes
 {: #probe-recommendation}
 
-When implementing a health probe by using HTTP, consider the following HTTP status codes for readiness, liveness, and health.
+When implementing a health probe by using HTTP, consider the following HTTP status codes for readiness, liveness, and health:
 
 | State    |  Readiness            |  Liveness             |
 |----------|-----------------------|-----------------------|
@@ -54,7 +54,6 @@ When implementing a health probe by using HTTP, consider the following HTTP stat
 | Stopping | 503 - Unavailable     | 200 - OK              |
 | Down     | 503 - Unavailable     | 503 - Unavailable     |
 | Errored  | 500 - Server Error    | 500 - Server Error    |
-{: caption="Table 1. HTTP status codes" caption-side="top"}
 
 Health check endpoints must not require authorization or authentication. Since these protections are not put into place on health probe endpoints, restrict any HTTP probe implementations to GET requests that do not modify any data. Never return data that identifies specifics about the environment, like the operating system, implementation language, or software versions, as these can be used to establish an attack vector.
 


### PR DESCRIPTION
Suggest removing captions from tables and figures for consistency throughout. Also, not really necessary in online material because the image is usually in the right place in the flow of the text (unlike in printed material) and is introduced sufficiently with a lead-in sentence.